### PR TITLE
deal relay method

### DIFF
--- a/m3/contract/filecoin.mock.sol
+++ b/m3/contract/filecoin.mock.sol
@@ -412,6 +412,11 @@ contract MarketAPI{
     function get_deal_activation(MarketTypes.GetDealActivationParams memory params) public returns (MarketTypes.GetDealActivationReturn memory) {
         return MarketTypes.GetDealActivationReturn(1, 1);
     }
+
+    function relay_deal(bytes memory raw_auth_params, address callee) public {
+        // calls standard filecoin receiver on message authentication api method number
+        callee.call(bytes4(keccak256("handle_filecoin_method(uint64,uint64,bytes)")), 0, 2643134072, raw_auth_params);
+    }
 }
 
 library MinerTypes{

--- a/m3/contract/filecoin.mock.sol
+++ b/m3/contract/filecoin.mock.sol
@@ -413,9 +413,10 @@ contract MarketAPI{
         return MarketTypes.GetDealActivationReturn(1, 1);
     }
 
-    function relay_deal(bytes memory raw_auth_params, address callee) public {
+    function publish_deal(bytes memory raw_auth_params, address callee) public {
         // calls standard filecoin receiver on message authentication api method number
-        callee.call(abi.encodeWithSignature("handle_filecoin_method(uint64,uint64,bytes)", 0, 2643134072, raw_auth_params));
+        (bool success, bytes memory _ret) = callee.call(abi.encodeWithSignature("handle_filecoin_method(uint64,uint64,bytes)", 0, 2643134072, raw_auth_params));
+        require(success, "client contract failed to authorize deal publish");
     }
     
 }

--- a/m3/contract/filecoin.mock.sol
+++ b/m3/contract/filecoin.mock.sol
@@ -415,8 +415,9 @@ contract MarketAPI{
 
     function relay_deal(bytes memory raw_auth_params, address callee) public {
         // calls standard filecoin receiver on message authentication api method number
-        callee.call(bytes4(keccak256("handle_filecoin_method(uint64,uint64,bytes)")), 0, 2643134072, raw_auth_params);
+        callee.call(abi.encodeWithSignature("handle_filecoin_method(uint64,uint64,bytes)", 0, 2643134072, raw_auth_params));
     }
+    
 }
 
 library MinerTypes{


### PR DESCRIPTION
The solidity might be quite off as I'm very new to the language and EVM.

Following up on an idea first posted in slack.  Including this relay method in the mock market api will allow for building [contract clients](https://github.com/lotus-web3/client-contract/blob/master/src/DealClient.sol#L7) against the filecoin mock.  This is a nice primitive to start building out as it is a stepping stone for data daos and generalized storage markets.